### PR TITLE
Automate the transition between the notebooks

### DIFF
--- a/notebooks/data-flywheel-bp-tutorial.ipynb
+++ b/notebooks/data-flywheel-bp-tutorial.ipynb
@@ -185,7 +185,23 @@
   },
   {
    "cell_type": "markdown",
-   "source": "Now it's time to move to your Orchestrated environment—MLRun.\n\nTo get into the MLRun environment, please follow the instructions below:\n\n1. Go to your Brev Launchable and click on the **Access** tab.\n2. In the **Access** tab, click on the **Share A Service** button to create the following services:\n   1. **mlrun-jupyter**: Port `30040`. This is the JupyterLab environment where you can execute mlrun workflows.\n   2. **mlrun-ui**: Port `30060`. This is the MLRun UI where you can monitor and manage your project with all the runs, functions, and artifacts.\n   3. **nuclio-dashboard**: Port `30050`. This is the Nuclio dashboard where you can monitor and manage your realtime functions.\n3. After creating the services, open each service in a new tab and continue from **mlrun-jupyter**.\n4. In the **mlrun-jupyter** tab, open a new terminal and clone the `mlrun-data-flywheel`. You can use the following command:\n   ```bash\n   git clone https://github.com/mlrun/nvidia-data-flywheel.git\n   ```",
+   "source": [
+    "Now it's time to move to your Orchestrated environment—MLRun.\n",
+    "\n",
+    "To get into the MLRun environment, please follow the instructions below:\n",
+    "\n",
+    "1. Go to your Brev Launchable and click on the **Access** tab.\n",
+    "2. In the **Access** tab, click on the **Share A Service** button to create the following services:\n",
+    "   1. **mlrun-jupyter**: Port `30040`. This is the JupyterLab environment where you can execute mlrun workflows.\n",
+    "   2. **mlrun-ui**: Port `30060`. This is the MLRun UI where you can monitor and manage your project with all the runs, functions, and artifacts.\n",
+    "   3. **nuclio-dashboard**: Port `30050`. This is the Nuclio dashboard where you can monitor and manage your realtime functions.\n",
+    "3. After creating the services, open each service in a new tab and continue from **mlrun-jupyter**.\n",
+    "4. In the **mlrun-jupyter** tab, open a new terminal and clone the `mlrun-data-flywheel`. You can use the following command:\n",
+    "   ```bash\n",
+    "   git clone https://github.com/mlrun/nvidia-data-flywheel.git\n",
+    "   ```\n",
+    "5. After cloning the repository, navigate to `data-flywheel/notebooks/mlrun` directory:"
+   ],
    "metadata": {}
   },
   {

--- a/notebooks/data-flywheel-bp-tutorial.ipynb
+++ b/notebooks/data-flywheel-bp-tutorial.ipynb
@@ -65,18 +65,18 @@
    "metadata": {}
   },
   {
+   "metadata": {},
    "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "%%bash\n",
     "git clone https://github.com/mlrun/nvidia-data-flywheel.git\n",
-    "cd data-flywheel\n",
+    "cd nvidia-data-flywheel\n",
     "sudo apt-get update && sudo apt-get install -y git-lfs\n",
     "git lfs install\n",
     "git-lfs pull"
-   ],
-   "metadata": {},
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -84,11 +84,28 @@
    "metadata": {}
   },
   {
-   "cell_type": "code",
-   "source": "import sys\nfrom pathlib import Path\n\nnotebook_dir = Path.cwd()\nproject_root = notebook_dir / \"data-flywheel\"\ndata_dir = project_root / \"data\"\nsys.path.insert(0, str(project_root))\nos.chdir(project_root)\nprint(f\"Working directory changed to: {Path.cwd()}\")\n\nuser_site = Path.home() / \".local\" / \"lib\" / f\"python{sys.version_info.major}.{sys.version_info.minor}\" / \"site-packages\"\nif str(user_site) not in sys.path:\n    sys.path.append(str(user_site))\n    print(f\"Added user site-packages to sys.path: {user_site}\")\n\n%pip install --user elasticsearch==8.17.2 pydantic-settings>=2.9.1 pandas>=2.2.3 matplotlib==3.10.3",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "execution_count": null
+   "execution_count": null,
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "notebook_dir = Path.cwd()\n",
+    "project_root = notebook_dir / \"nvidia-data-flywheel\"\n",
+    "data_dir = project_root / \"data\"\n",
+    "sys.path.insert(0, str(project_root))\n",
+    "os.chdir(project_root)\n",
+    "print(f\"Working directory changed to: {Path.cwd()}\")\n",
+    "\n",
+    "user_site = Path.home() / \".local\" / \"lib\" / f\"python{sys.version_info.major}.{sys.version_info.minor}\" / \"site-packages\"\n",
+    "if str(user_site) not in sys.path:\n",
+    "    sys.path.append(str(user_site))\n",
+    "    print(f\"Added user site-packages to sys.path: {user_site}\")\n",
+    "\n",
+    "%pip install --user elasticsearch==8.17.2 pydantic-settings>=2.9.1 pandas>=2.2.3 matplotlib==3.10.3"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -186,21 +203,15 @@
   {
    "cell_type": "markdown",
    "source": [
-    "Now it's time to move to your Orchestrated environment—MLRun.\n",
+    "Now it's time to move to your Orchestrated environment — MLRun.\n",
     "\n",
     "To get into the MLRun environment, please follow the instructions below:\n",
     "\n",
-    "1. Go to your Brev Launchable and click on the **Access** tab.\n",
-    "2. In the **Access** tab, click on the **Share A Service** button to create the following services:\n",
-    "   1. **mlrun-jupyter**: Port `30040`. This is the JupyterLab environment where you can execute mlrun workflows.\n",
-    "   2. **mlrun-ui**: Port `30060`. This is the MLRun UI where you can monitor and manage your project with all the runs, functions, and artifacts.\n",
-    "   3. **nuclio-dashboard**: Port `30050`. This is the Nuclio dashboard where you can monitor and manage your realtime functions.\n",
-    "3. After creating the services, open each service in a new tab and continue from **mlrun-jupyter**.\n",
-    "4. In the **mlrun-jupyter** tab, open a new terminal and clone the `mlrun-data-flywheel`. You can use the following command:\n",
-    "   ```bash\n",
-    "   git clone https://github.com/mlrun/nvidia-data-flywheel.git\n",
-    "   ```\n",
-    "5. After cloning the repository, navigate to `data-flywheel/notebooks/mlrun` directory:"
+    "1. Go to your Brev Launchable and navigate to the **Access** tab.\n",
+    "2. Scroll down to the services section and make sure that all the services are running, and you can access the MLRun UI (30060), Nuclio Dashboard (30050) and MLRun Jupyter (30040). Access the MLRun Jupyter.\n",
+    "3. Open the `nvidia-data-flywheel/notebooks/mlrun/mlrun-data-fly-wheel-tutorial.ipynb` notebook and follow the instructions inside.\n",
+    "\n",
+    "For validation, make sure that the services are in Healthy state like in the image below:"
    ],
    "metadata": {}
   },

--- a/notebooks/mlrun/mlrun-data-flywheel-tutorial.ipynb
+++ b/notebooks/mlrun/mlrun-data-flywheel-tutorial.ipynb
@@ -53,12 +53,13 @@
    "source": [
     "project = mlrun.get_or_create_project(\n",
     "    name=\"data-flywheel\",\n",
+    "    context=\"../../\",\n",
     "    parameters={\n",
     "        \"source\": \"git://github.com/mlrun/nvidia-data-flywheel.git\",\n",
     "    },    \n",
     ")"
    ],
-   "id": "95727de9e89a87bc"
+   "id": "d6244f2b9a31f938"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/mlrun/mlrun-data-flywheel-tutorial.ipynb
+++ b/notebooks/mlrun/mlrun-data-flywheel-tutorial.ipynb
@@ -55,7 +55,7 @@
     "    name=\"data-flywheel\",\n",
     "    context=\"../../\",\n",
     "    parameters={\n",
-    "        \"source\": \"git://github.com/mlrun/nvidia-data-flywheel.git\",\n",
+    "        \"source\": \"git://github.com/mlrun/nvidia-data-flywheel.git#main\",\n",
     "    },    \n",
     ")"
    ],

--- a/scripts/mlrun.sh
+++ b/scripts/mlrun.sh
@@ -70,6 +70,10 @@ eval "$(minikube docker-env)"
 docker build -t "$DOCKER_SERVER"/mlrun-data-flywheel:latest -f deploy/mlrun/Dockerfile .
 docker push "$DOCKER_SERVER"/mlrun-data-flywheel:latest
 
+# Clone the mlrun repository into the mlrun-jupyter pod:
+kubectl exec -n $MLRUN_NAMESPACE "$(kubectl get ep mlrun-jupyter -n $MLRUN_NAMESPACE -o jsonpath='{.subsets[*].addresses[*].targetRef.name}')" -- \
+  git clone https://github.com/mlrun/nvidia-data-flywheel.git
+
 # Port forward all essential services and afterwards expose them in the UI:
 kubectl port-forward --namespace $MLRUN_NAMESPACE service/mlrun-jupyter 30040:8888 --address=0.0.0.0 &
 kubectl port-forward --namespace $MLRUN_NAMESPACE service/nuclio-dashboard 30050:8070 --address=0.0.0.0 &


### PR DESCRIPTION
Few changes:
1. Move the notebook from root to `notebooks/mlrun`.
2. Adjust all the URLs and context accordingly.
3. Remove the need to create services.
4. Add cloning to the script.